### PR TITLE
Alias git=hub.

### DIFF
--- a/roles/nucivic/templates/bash.bashrc
+++ b/roles/nucivic/templates/bash.bashrc
@@ -150,6 +150,7 @@ fi
 alias ll='ls -l'
 alias la='ls -ahl'
 #alias l='ls -CF'
+if hash hub 2> /dev/null; then alias git=hub; fi
 alias vim='vim -O'
 
 export EDITOR="vi"


### PR DESCRIPTION
So that we can do things like `git clone nucivic/healthdata`

or

`git pull-request` from the command line.
