### PR TITLE
Use sudo for ansible scripts.

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -1,6 +1,7 @@
 ---
 - hosts: all
-  user: root
+  remote_user: root
+  sudo: yes
 
   vars_files:
       - config.yml


### PR DESCRIPTION
`user` became `remote_user` as of ansible 1.4
`sudo: yes` ensures that packer can build.

Acceptance test:
[ ] Able to build an image on Atlas using this Packer and this Playbook.
