### PR TITLE
Add the composer vendor bin path to $PATH.

### DIFF
--- a/roles/nucivic/templates/bash.bashrc
+++ b/roles/nucivic/templates/bash.bashrc
@@ -153,3 +153,14 @@ alias la='ls -ahl'
 alias vim='vim -O'
 
 export EDITOR="vi"
+
+# Only add composer bin folder to path if it hasn't been added already.
+composer_bin=~/.composer/vendor/bin
+if [ -d $composer_bin ]; then
+  case ":${PATH:=$composer_bin}:" in
+    *:$new:*)  ;;
+    *) PATH="$composer_bin:$PATH"  ;;
+  esac
+
+  export PATH=~/.composer/bin:$PATH
+fi

--- a/roles/nucivic/templates/bash.bashrc
+++ b/roles/nucivic/templates/bash.bashrc
@@ -158,9 +158,7 @@ export EDITOR="vi"
 composer_bin=~/.composer/vendor/bin
 if [ -d $composer_bin ]; then
   case ":${PATH:=$composer_bin}:" in
-    *:$new:*)  ;;
-    *) PATH="$composer_bin:$PATH"  ;;
+    *:$composer_bin:*)  ;;
+    *) export PATH="$composer_bin:$PATH"  ;;
   esac
-
-  export PATH=~/.composer/bin:$PATH
 fi


### PR DESCRIPTION
This is necessary in order to access global binaries added using
composer (such as phpcs).
