### PR TITLE
Decrease suggested php memory to 128M.

### DIFF
--- a/config.yml.sample
+++ b/config.yml.sample
@@ -15,7 +15,7 @@ vagrant_memory: 2048
 vagrant_cpus: 2
 
 php_version: "5.4"
-php_memory_limit: "512M"
+php_memory_limit: "128M"
 php_display_errors: "On"
 php_realpath_cache_size: "1024K"
 php_sendmail_path: "/usr/sbin/ssmtp -t"


### PR DESCRIPTION
This is more in line with what Acquia uses by default and makes it more
likely for us to catch memory issues in development vs. production.

Closes #48
