### PR TITLE
Export ENVIRONMENT='local' in bashrc.

### DIFF
--- a/config.yml.sample
+++ b/config.yml.sample
@@ -15,7 +15,7 @@ vagrant_memory: 2048
 vagrant_cpus: 2
 
 php_version: "5.4"
-php_memory_limit: "512M"
+php_memory_limit: "128M"
 php_display_errors: "On"
 php_realpath_cache_size: "1024K"
 php_sendmail_path: "/usr/sbin/ssmtp -t"

--- a/roles/nucivic/templates/bash.bashrc
+++ b/roles/nucivic/templates/bash.bashrc
@@ -154,6 +154,7 @@ if hash hub 2> /dev/null; then alias git=hub; fi
 alias vim='vim -O'
 
 export EDITOR="vi"
+export ENVIRONMENT='local'
 
 # Only add composer bin folder to path if it hasn't been added already.
 composer_bin=~/.composer/vendor/bin


### PR DESCRIPTION
Now that we are using Devinci to automate environment switching we should
automatically let it know that our vagrant vms are the local environment.

Acceptance:

[ ] echo $ENVIRONMENT // You should see local.
