### PR TITLE
Update solr address.

### DIFF
--- a/roles/nucivic-solr/templates/create-solr-instance
+++ b/roles/nucivic-solr/templates/create-solr-instance
@@ -24,4 +24,4 @@ chmod g+xw /opt/solr/solr-$1
 chown -R :tomcat6 /opt/solr/solr-$1
 chmod -R g+w /opt/solr/solr-$1
 sudo /etc/init.d/tomcat6 restart
-echo "A solr instance has been created and can be visited on this server at :8983/solr-$1"
+echo "A solr instance has been created and can be visited on this server at http://localhost:8080/solr-$1"


### PR DESCRIPTION
The solr instance is being proxied over 8080.  If you try to access it
over 8983 you get an access denied error.

For details about why this is so consult:

 /etc/tomcat6/server.xml Line 71+:

 `<Connector port="8080" protocol="HTTP/1.1"`

 Acceptance:
- [ ] After installing a solr instance with `sudo create-solr-instance` You should be able to access it via wget/curl.
